### PR TITLE
gi: Replace deprecated FFI closure API

### DIFF
--- a/gi/gimodule.c
+++ b/gi/gimodule.c
@@ -55,6 +55,11 @@
 #include "pygi-python-compat.h"
 #include "pygi-basictype.h"
 
+/* GI_CHECK_VERSION was introduced in gobject-introspection 1.60 */
+#ifndef GI_CHECK_VERSION
+# define GI_CHECK_VERSION(x,y,z) 0
+#endif
+
 PyObject *PyGIWarning;
 PyObject *PyGIDeprecationWarning;
 PyObject *_PyGIDefaultArgPlaceholder;
@@ -1813,7 +1818,11 @@ _wrap_pyg_hook_up_vfunc_implementation (PyObject *self, PyObject *args)
         closure = _pygi_make_native_closure ( (GICallableInfo*) callback_info, cache,
                                               GI_SCOPE_TYPE_NOTIFIED, py_function, NULL);
 
+#if GI_CHECK_VERSION (1, 72, 0)
+        *method_ptr = g_callable_info_get_closure_native_address (callback_info, closure->closure);
+#else
         *method_ptr = closure->closure;
+#endif
 
         g_base_info_unref (interface_info);
         g_base_info_unref (type_info);

--- a/gi/pygi-closure.c
+++ b/gi/pygi-closure.c
@@ -24,6 +24,11 @@
 #include "pygi-ccallback.h"
 #include "pygi-info.h"
 
+/* GI_CHECK_VERSION was introduced in gobject-introspection 1.60 */
+#ifndef GI_CHECK_VERSION
+# define GI_CHECK_VERSION(x,y,z) 0
+#endif
+
 extern PyObject *_PyGIDefaultArgPlaceholder;
 
 typedef struct _PyGICallbackCache
@@ -632,8 +637,13 @@ void _pygi_invoke_closure_free (gpointer data)
 {
     PyGICClosure* invoke_closure = (PyGICClosure *) data;
 
+#if GI_CHECK_VERSION (1, 72, 0)
+    g_callable_info_destroy_closure (invoke_closure->info,
+                                     invoke_closure->closure);
+#else
     g_callable_info_free_closure (invoke_closure->info,
                                   invoke_closure->closure);
+#endif
 
     if (invoke_closure->info)
         g_base_info_unref ( (GIBaseInfo*) invoke_closure->info);
@@ -670,9 +680,16 @@ _pygi_make_native_closure (GICallableInfo* info,
     Py_INCREF (py_function);
     Py_XINCREF (closure->user_data);
 
+#if GI_CHECK_VERSION (1, 72, 0)
+    fficlosure =
+        g_callable_info_create_closure (info, &closure->cif, _pygi_closure_handle,
+                                        closure);
+#else
     fficlosure =
         g_callable_info_prepare_closure (info, &closure->cif, _pygi_closure_handle,
                                          closure);
+#endif
+
     closure->closure = fficlosure;
 
     /* Give the closure the information it needs to determine when
@@ -751,7 +768,15 @@ _pygi_marshal_from_py_interface_callback (PyGIInvokeState   *state,
     closure = _pygi_make_native_closure (
         callable_info, callback_cache->closure_cache, callback_cache->scope,
         py_arg, py_user_data);
+
+#if GI_CHECK_VERSION (1, 72, 0)
+    if (closure->closure != NULL)
+        arg->v_pointer = g_callable_info_get_closure_native_address (callable_info, closure->closure);
+    else
+        arg->v_pointer = NULL;
+#else
     arg->v_pointer = closure->closure;
+#endif
 
     /* always decref the user data as _pygi_make_native_closure adds its own ref */
     Py_XDECREF (py_user_data);


### PR DESCRIPTION
This is a reimplemented fc776c2058e11da5c3a4cebeea7f313057bc079f with the proper fix for the regression introduced by that commit which required a revert.